### PR TITLE
processHTML being called too late

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -91,6 +91,8 @@ public class D3SView extends WebView
      */
     private D3SSViewAuthorizationListener authorizationListener = null;
 
+    String capturedHtml;
+
 
     public D3SView(final Context context)
     {
@@ -146,7 +148,7 @@ public class D3SView extends WebView
                         }
                         else
                         {
-                            view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
+                            completeAuthorization(capturedHtml);
                         }
                         urlReturned = true;
                     }
@@ -157,6 +159,16 @@ public class D3SView extends WebView
                 }
             }
 
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                super.onPageFinished(view, url);
+
+                if (url.toLowerCase().contains(postbackUrl.toLowerCase())) {
+                    return;
+                }
+                view.loadUrl(String.format("javascript:window.%s.captureHtml(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
+            }
+;
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl)
             {
                 if (!failingUrl.startsWith(postbackUrl))
@@ -348,6 +360,11 @@ public class D3SView extends WebView
         public void processHTML(final String paramString)
         {
             completeAuthorization(paramString);
+        }
+
+        @android.webkit.JavascriptInterface
+        public void captureHtml(String html) {
+            capturedHtml = html;
         }
     }
 }

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -87,6 +87,8 @@ public class D3SView extends WebView
 
     private AtomicBoolean postbackHandled = new AtomicBoolean(false);
 
+    private boolean initialPageLoadCompleted = false;
+
     /**
      * Callback to send authorization events to
      */
@@ -167,7 +169,11 @@ public class D3SView extends WebView
                 if (url.toLowerCase().contains(postbackUrl.toLowerCase())) {
                     return;
                 }
-                view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
+                if (!initialPageLoadCompleted) {
+                    initialPageLoadCompleted = true;
+                } else {
+                    view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
+                }
             }
 ;
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl)
@@ -332,6 +338,7 @@ public class D3SView extends WebView
     {
         urlReturned = false;
         postbackHandled.set(false);
+        initialPageLoadCompleted = false;
 
         if (authorizationListener != null)
         {


### PR DESCRIPTION
We've noticed that in the last few days (we think since Chrome 71 has started rolling out to Android devices), the processHTML method is being called too late so it's running against the HTML from the request to www.google.com rather than the HTML form that it should be running against. The result is that onAuthorizationCompleted is called with empty strings for md and pares.

This PR uses onPageFinished to capture the HTML from each request (except the one to www.google.com) so that the reqex can be run against the correct HTML.