### PR TITLE
Fixes 3-D Secure processing for certain banks

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -9,25 +9,13 @@ import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.webkit.ValueCallback;
 
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
 
 /**
@@ -57,9 +45,7 @@ import javax.xml.transform.stream.StreamSource;
  */
 public class D3SView extends WebView
 {
-	
-	private static final Logger LOGGER = Logger.getLogger( D3SView.class.getName() );
-	
+
     /**
      * Namespace for JS bridge
      */

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -228,7 +228,7 @@ public class D3SView extends WebView
 
     private void completeAuthorizationIfPossible(String html)
     {
-    		// If the postback has already been handled, stop now
+        // If the postback has already been handled, stop now
         if (postbackHandled.get()) {
             return;
         }
@@ -241,14 +241,14 @@ public class D3SView extends WebView
         if (mdMatcher.find()) {
             md = mdMatcher.group(1);
         } else {
-        		return; // Not Found
+            return; // Not Found
         }
         
         Matcher paresMatcher = paresFinder.matcher(html);
         if (paresMatcher.find()) {
             pares = paresMatcher.group(1);
         } else {
-        		return; // Not Found
+            return; // Not Found
         }
 
         // Now extract the values from the previously captured form elements
@@ -256,14 +256,14 @@ public class D3SView extends WebView
         if (mdValueMatcher.find()) {
         		md = mdValueMatcher.group(1);
         } else {
-        		return; // Not Found
+            return; // Not Found
         }
 
         Matcher paresValueMatcher = valuePattern.matcher(pares);
         if (paresValueMatcher.find()){
             pares = paresValueMatcher.group(1);
         } else {
-    			return; // Not Found
+            return; // Not Found
         }
         
         // If we get to this point, we've definitely got values for both the MD and PaRes

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -168,7 +168,7 @@ public class D3SView extends WebView
                     return;
                 }
 
-                	view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
+                view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
             }
 ;
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl)

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -9,13 +9,25 @@ import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.ValueCallback;
 
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
 
 /**
@@ -45,7 +57,9 @@ import java.util.regex.Pattern;
  */
 public class D3SView extends WebView
 {
-
+	
+	private static final Logger LOGGER = Logger.getLogger( D3SView.class.getName() );
+	
     /**
      * Namespace for JS bridge
      */
@@ -86,8 +100,6 @@ public class D3SView extends WebView
     private String stackedModePostbackUrl;
 
     private AtomicBoolean postbackHandled = new AtomicBoolean(false);
-
-    private boolean initialPageLoadCompleted = false;
 
     /**
      * Callback to send authorization events to
@@ -169,11 +181,8 @@ public class D3SView extends WebView
                 if (url.toLowerCase().contains(postbackUrl.toLowerCase())) {
                     return;
                 }
-                if (!initialPageLoadCompleted) {
-                    initialPageLoadCompleted = true;
-                } else {
-                    view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
-                }
+
+                	view.loadUrl(String.format("javascript:window.%s.processHTML(document.getElementsByTagName('html')[0].innerHTML);", JavaScriptNS));
             }
 ;
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl)
@@ -231,51 +240,50 @@ public class D3SView extends WebView
         this.stackedModePostbackUrl = stackedModePostbackUrl;
     }
 
-    private void completeAuthorization(String html)
+    private void completeAuthorizationIfPossible(String html)
     {
+    		// If the postback has already been handled, stop now
         if (postbackHandled.get()) {
             return;
         }
 
+        // Try and find the MD and PaRes form elements in the supplied html
         String md = "";
         String pares = "";
 
-        Matcher localMatcher1 = mdFinder.matcher(html);
-        Matcher localMatcher2 = paresFinder.matcher(html);
-
-        if (localMatcher1.find())
-        {
-            md = localMatcher1.group(1);
+        Matcher mdMatcher = mdFinder.matcher(html);
+        if (mdMatcher.find()) {
+            md = mdMatcher.group(1);
+        } else {
+        		return; // Not Found
+        }
+        
+        Matcher paresMatcher = paresFinder.matcher(html);
+        if (paresMatcher.find()) {
+            pares = paresMatcher.group(1);
+        } else {
+        		return; // Not Found
         }
 
-        if (localMatcher2.find())
-        {
-            pares = localMatcher2.group(1);
+        // Now extract the values from the previously captured form elements
+        Matcher mdValueMatcher = valuePattern.matcher(md);
+        if (mdValueMatcher.find()) {
+        		md = mdValueMatcher.group(1);
+        } else {
+        		return; // Not Found
         }
 
-        if (!TextUtils.isEmpty(md))
-        {
-            Matcher valueMatcher = valuePattern.matcher(md);
-            if (valueMatcher.find())
-            {
-                md = valueMatcher.group(1);
-            }
+        Matcher paresValueMatcher = valuePattern.matcher(pares);
+        if (paresValueMatcher.find()){
+            pares = paresValueMatcher.group(1);
+        } else {
+    			return; // Not Found
         }
+        
+        // If we get to this point, we've definitely got values for both the MD and PaRes
 
-        if (!TextUtils.isEmpty(pares))
-        {
-            Matcher valueMatcher = valuePattern.matcher(pares);
-            if (valueMatcher.find())
-            {
-                pares = valueMatcher.group(1);
-            }
-        }
-
-        // If we didn't find both MD and PaRes, don't continue
-        if (TextUtils.isEmpty(md) || TextUtils.isEmpty(pares)) {
-            return;
-        }
-
+        // The postbackHandled check is just to ensure we've not already called back. 
+        // We don't want onAuthorizationCompleted to be called twice.
         if (postbackHandled.compareAndSet(false, true) && authorizationListener != null)
         {
             authorizationListener.onAuthorizationCompleted(md, pares);
@@ -338,7 +346,6 @@ public class D3SView extends WebView
     {
         urlReturned = false;
         postbackHandled.set(false);
-        initialPageLoadCompleted = false;
 
         if (authorizationListener != null)
         {
@@ -373,7 +380,7 @@ public class D3SView extends WebView
         @android.webkit.JavascriptInterface
         public void processHTML(final String paramString)
         {
-            completeAuthorization(paramString);
+            completeAuthorizationIfPossible(paramString);
         }
     }
 }

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -364,9 +364,9 @@ public class D3SView extends WebView
         }
 
         @android.webkit.JavascriptInterface
-        public void processHTML(final String paramString)
+        public void processHTML(final String html)
         {
-            completeAuthorizationIfPossible(paramString);
+            completeAuthorizationIfPossible(html);
         }
     }
 }


### PR DESCRIPTION
This should fix https://github.com/LivotovLabs/3DSView/issues/23

In https://github.com/LivotovLabs/3DSView/pull/20, you'll see me complaining about performance issues of the branch in question (along with videos showing the issue) which led me to suggest changes to the branch (the `initialPageLoadCompleted` stuff).

This caused the library to stop working for certain banks where the PaRes and MD seem to be available on the initial page load (Co-op and Capital One are definitely affected, perhaps others).

So, I've had a think about _why_ the performance slowed down following the changes in https://github.com/LivotovLabs/3DSView/pull/20. We have doubled the amount of checks we are doing (by calling processHTML on an extra event) which seems unavoidable due to the new version of Chrome, so I looked to reduce that impact (i.e improve performance) - I've tweaked the code that does the regexes to return _immediately_ if there is no match, rather than fruitlessly trying to do more regexes before returning, which seems to fix the performance issue on my middling test device.

This seems to work with my test ACS, but I've yet to test it with one of the live cards affected, or my own card. I can't see why this wouldn't work though. I'll update when I've done this testing.