### PR TITLE
Update regex value matcher do not match blank

### DIFF
--- a/3DSView/build.gradle
+++ b/3DSView/build.gradle
@@ -20,3 +20,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.1.0'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'com.google.truth:truth:1.1'
+}

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -18,7 +18,33 @@ final class D3SRegexUtils {
     /**
      * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of PaRes.
      */
-    private static final Pattern paresFinder = compile("<input(?=.+?name=\"PaRes\")(?=.+?value=\"(\\S+?)\").+>", DOTALL | CASE_INSENSITIVE);
+    private static final Pattern mdFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"MD\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
+
+    /**
+     * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of PaRes.
+     */
+    private static final Pattern paresFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"PaRes\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
+
+    /**
+     * Finds the MD in an html page.
+     * <p>
+     * Note: If more than one MD is found in a page only the first will be returned.
+     *
+     * @param html String representation of the html page to search within.
+     * @return MD or null if not found
+     */
+    @Nullable
+    public static String findMd(@NonNull String html) {
+        if (html.trim().isEmpty()) return null;
+
+        String md = null;
+        Matcher paresMatcher = mdFinder.matcher(html);
+        if (paresMatcher.find()) {
+            md = paresMatcher.group(1);
+        }
+
+        return md;
+    }
 
     /**
      * Finds the PaRes in an html page.

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -6,20 +6,19 @@ import androidx.annotation.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.DOTALL;
+import static java.util.regex.Pattern.compile;
+
 /**
  * Utilities to find 3DS values in ACS webpages.
  */
 final class D3SRegexUtils {
 
     /**
-     * Pattern to find an html tag with an attribute named PaRes.
+     * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of PaRes.
      */
-    private static final Pattern paresFinder = Pattern.compile(".*?(<input[^<>]* name=\"PaRes\"[^<>]*>).*?", Pattern.DOTALL);
-
-    /**
-     * Pattern to find the value from an html tag with an attribute named value.
-     */
-    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(\\S+?)\"", Pattern.DOTALL);
+    private static final Pattern paresFinder = compile("<input(?=.+?name=\"PaRes\")(?=.+?value=\"(\\S+?)\").+>", DOTALL | CASE_INSENSITIVE);
 
     /**
      * Finds the PaRes in an html page.
@@ -31,18 +30,10 @@ final class D3SRegexUtils {
     static String findPaRes(@NonNull String html) {
         if (html.trim().isEmpty()) return null;
 
-        String paResTag = null;
+        String paRes = null;
         Matcher paresMatcher = paresFinder.matcher(html);
         if (paresMatcher.find()) {
-            paResTag = paresMatcher.group(1);
-        }
-
-        if (paResTag == null) return null;
-
-        String paRes = null;
-        Matcher paresValueMatcher = valuePattern.matcher(paResTag);
-        if (paresValueMatcher.find()) {
-            paRes = paresValueMatcher.group(1);
+            paRes = paresMatcher.group(1);
         }
 
         return paRes;

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -22,6 +22,8 @@ final class D3SRegexUtils {
 
     /**
      * Finds the PaRes in an html page.
+     * <p>
+     * Note: If more than one PaRes is found in a page only the first will be returned.
      *
      * @param html String representation of the html page to search within.
      * @return PaRes or null if not found

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -1,0 +1,50 @@
+package eu.livotov.labs.android.d3s;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utilities to find 3DS values in ACS webpages.
+ */
+final class D3SRegexUtils {
+
+    /**
+     * Pattern to find an html tag with an attribute named PaRes.
+     */
+    private static final Pattern paresFinder = Pattern.compile(".*?(<input[^<>]* name=\"PaRes\"[^<>]*>).*?", Pattern.DOTALL);
+
+    /**
+     * Pattern to find the value from an html tag with an attribute named value.
+     */
+    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(\\S+?)\"", Pattern.DOTALL);
+
+    /**
+     * Finds the PaRes in an html page.
+     *
+     * @param html String representation of the html page to search within.
+     * @return PaRes or null if not found
+     */
+    @Nullable
+    static String findPaRes(@NonNull String html) {
+        if (html.trim().isEmpty()) return null;
+
+        String paResTag = null;
+        Matcher paresMatcher = paresFinder.matcher(html);
+        if (paresMatcher.find()) {
+            paResTag = paresMatcher.group(1);
+        }
+
+        if (paResTag == null) return null;
+
+        String paRes = null;
+        Matcher paresValueMatcher = valuePattern.matcher(paResTag);
+        if (paresValueMatcher.find()) {
+            paRes = paresValueMatcher.group(1);
+        }
+
+        return paRes;
+    }
+}

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -62,7 +62,7 @@ public class D3SView extends WebView {
     /**
      * Pattern to find the value from the result of the above searches
      */
-    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(.+?)\"", Pattern.DOTALL);
+    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(\\S+?)\"", Pattern.DOTALL);
 
     /**
      * Url that will be used by ACS server for posting result data on authorization completion. We will be monitoring

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -1,15 +1,12 @@
 package eu.livotov.labs.android.d3s;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.net.http.SslError;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.webkit.WebResourceResponse;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -98,7 +95,7 @@ public class D3SView extends WebView {
         setWebViewClient(new WebViewClient() {
 
             @Override
-            public WebResourceResponse shouldInterceptRequest (WebView view, String url) {
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
                 if (isPostbackUrl(url)) {
                     // Wait for the form data to be processed in the other thread.
                     // 1.5s should be more than enough
@@ -175,7 +172,7 @@ public class D3SView extends WebView {
                 return;
             }
 
-            if(is3dsV2){
+            if (is3dsV2) {
                 match3DSV2Parameters(html);
             } else {
                 match3DSV1Parameters(html);
@@ -211,7 +208,7 @@ public class D3SView extends WebView {
         Matcher threeDSSessionDataMatcher = threeDSSessionDataFinder.matcher(html);
         if (threeDSSessionDataMatcher.find()) {
             String fieldResult = threeDSSessionDataMatcher.group(1);
-            if(fieldResult != null) {
+            if (fieldResult != null) {
                 Matcher threeDSSessionDataValueMatcher = valuePattern.matcher(fieldResult);
                 if (threeDSSessionDataValueMatcher.find()) {
                     threeDSSessionData = threeDSSessionDataValueMatcher.group(1);
@@ -225,7 +222,6 @@ public class D3SView extends WebView {
     }
 
     private void match3DSV1Parameters(String html) {
-
         // Try and find the MD and PaRes form elements in the supplied html
         String md = "";
         String pares = "";
@@ -290,13 +286,14 @@ public class D3SView extends WebView {
 
     /**
      * Starts 3-D Secure v2 authentication
-     * @param acsUrl ACS server url - supplied by the payment gateway
-     * @param creq - CReq to post to the ACS
+     *
+     * @param acsUrl             ACS server url - supplied by the payment gateway
+     * @param creq               - CReq to post to the ACS
      * @param threeDSSessionData - Session data to pass to the ACS. This will be reflected back in the callback
-     * @param postbackUrl - the URL to wait for, so the CRes can be extracted
+     * @param postbackUrl        - the URL to wait for, so the CRes can be extracted
      */
     public void authorize(final String acsUrl, final String creq, final String threeDSSessionData, final String postbackUrl) {
-        authorize(acsUrl, creq, null, null,  threeDSSessionData, postbackUrl);
+        authorize(acsUrl, creq, null, null, threeDSSessionData, postbackUrl);
     }
 
     /**
@@ -322,7 +319,7 @@ public class D3SView extends WebView {
 
         String postParams;
         try {
-            if(creq != null){
+            if (creq != null) {
                 // 3-D Secure v2
                 is3dsV2 = true;
                 postParams = String.format(Locale.US, "creq=%1$s&threeDSSessionData=%2$s", URLEncoder.encode(creq, "UTF-8"), URLEncoder.encode(threeDSSessionData, "UTF-8"));

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -62,7 +62,7 @@ public class D3SView extends WebView {
     /**
      * Pattern to find the value from the result of the above searches
      */
-    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(.*?)\"", Pattern.DOTALL);
+    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(.+?)\"", Pattern.DOTALL);
 
     /**
      * Url that will be used by ACS server for posting result data on authorization completion. We will be monitoring

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -51,7 +51,6 @@ public class D3SView extends WebView {
     /**
      * Patterns to find the various fields in the ACS server post response
      */
-    private static Pattern mdFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"MD\\\"[^<>]*>).*?", Pattern.DOTALL);
     private static Pattern cresFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"CRes\\\"[^<>]*>).*?", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
     private static Pattern threeDSSessionDataFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"threeDSSessionData\\\"[^<>]*>).*?", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
@@ -222,22 +221,8 @@ public class D3SView extends WebView {
 
     private void match3DSV1Parameters(String html) {
         // Try and find the MD and PaRes form elements in the supplied html
-        String md = "";
-
-        Matcher mdMatcher = mdFinder.matcher(html);
-        if (mdMatcher.find()) {
-            md = mdMatcher.group(1);
-        } else {
-            return; // Not Found
-        }
-
-        // Now extract the values from the previously captured form elements
-        Matcher mdValueMatcher = valuePattern.matcher(md);
-        if (mdValueMatcher.find()) {
-            md = mdValueMatcher.group(1);
-        } else {
-            return; // Not Found
-        }
+        final String md = D3SRegexUtils.findMd(html);
+        if (md == null) return;
 
         final String paRes = D3SRegexUtils.findPaRes(html);
         if (paRes == null) return;

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -52,7 +52,6 @@ public class D3SView extends WebView {
      * Patterns to find the various fields in the ACS server post response
      */
     private static Pattern mdFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"MD\\\"[^<>]*>).*?", Pattern.DOTALL);
-    private static Pattern paresFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"PaRes\\\"[^<>]*>).*?", Pattern.DOTALL);
     private static Pattern cresFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"CRes\\\"[^<>]*>).*?", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
     private static Pattern threeDSSessionDataFinder = Pattern.compile(".*?(<input[^<>]* name=\\\"threeDSSessionData\\\"[^<>]*>).*?", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
@@ -224,18 +223,10 @@ public class D3SView extends WebView {
     private void match3DSV1Parameters(String html) {
         // Try and find the MD and PaRes form elements in the supplied html
         String md = "";
-        String pares = "";
 
         Matcher mdMatcher = mdFinder.matcher(html);
         if (mdMatcher.find()) {
             md = mdMatcher.group(1);
-        } else {
-            return; // Not Found
-        }
-
-        Matcher paresMatcher = paresFinder.matcher(html);
-        if (paresMatcher.find()) {
-            pares = paresMatcher.group(1);
         } else {
             return; // Not Found
         }
@@ -248,19 +239,15 @@ public class D3SView extends WebView {
             return; // Not Found
         }
 
-        Matcher paresValueMatcher = valuePattern.matcher(pares);
-        if (paresValueMatcher.find()) {
-            pares = paresValueMatcher.group(1);
-        } else {
-            return; // Not Found
-        }
+        final String paRes = D3SRegexUtils.findPaRes(html);
+        if (paRes == null) return;
 
         // If we get to this point, we've definitely got values for both the MD and PaRes
 
         // The postbackHandled check is just to ensure we've not already called back.
         // We don't want onAuthorizationCompleted to be called twice.
         if (postbackHandled.compareAndSet(false, true) && authorizationListener != null) {
-            authorizationListener.onAuthorizationCompleted(md, pares);
+            authorizationListener.onAuthorizationCompleted(md, paRes);
         }
     }
 

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -62,7 +62,7 @@ public class D3SView extends WebView {
     /**
      * Pattern to find the value from the result of the above searches
      */
-    private static Pattern valuePattern = Pattern.compile(".*? value=\"(.*?)\"", Pattern.DOTALL);
+    private static final Pattern valuePattern = Pattern.compile(".*? value=\"(.*?)\"", Pattern.DOTALL);
 
     /**
      * Url that will be used by ACS server for posting result data on authorization completion. We will be monitoring

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -62,7 +62,7 @@ public class D3SView extends WebView {
     /**
      * Pattern to find the value from the result of the above searches
      */
-    private static Pattern valuePattern = Pattern.compile(".*? value=\\\"(.*?)\\\"", Pattern.DOTALL);
+    private static Pattern valuePattern = Pattern.compile(".*? value=\"(.*?)\"", Pattern.DOTALL);
 
     /**
      * Url that will be used by ACS server for posting result data on authorization completion. We will be monitoring

--- a/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
+++ b/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
@@ -7,15 +7,153 @@ import static com.google.common.truth.Truth.assertThat;
 public class D3SRegexUtilsTest {
 
     @Test
+    public void given_empty_html_when_MD_match_attempted_then_should_return_null() {
+        // Given
+        String html = "";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isNull();
+    }
+
+    @Test
+    public void given_blank_html_when_MD_match_attempted_then_should_return_null() {
+        // Given
+        String html = "               ";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_no_md_when_MD_match_attempted_then_should_return_null() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<div class=\"threeds-one\">" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_empty_md_when_MD_match_attempted_then_should_return_null() {
+        // https://github.com/LivotovLabs/3DSView/issues/30
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"PaRes\" value=\"\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"MD\" value=\"\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_valid_md_when_MD_match_attempted_then_should_return_md() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"PaRes\" value=\"pares_value\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"MD\" value=\"md_value\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isEqualTo("md_value");
+    }
+
+    @Test
+    public void given_html_with_valid_md_case_insensitive_when_MD_match_attempted_then_should_return_md() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"pares\" value=\"pares_value\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"md\" value=\"md_value\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isEqualTo("md_value");
+    }
+
+
+    @Test
+    public void given_html_with_valid_md_multiline_when_MD_match_attempted_then_should_return_md() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input" +
+                "    type=\"hidden\" " +
+                "    id=\"PaRes\" " +
+                "    name=\"pares\" " +
+                "    value=\"pares_value\">\n" +
+                "  <input " +
+                "   type=\"hidden\" " +
+                "   id=\"MD\" " +
+                "   name=\"MD\" " +
+                "   value=\"md_value\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findMd(html);
+
+        // Then
+        assertThat(result)
+                .isEqualTo("md_value");
+    }
+
+    @Test
     public void given_empty_html_when_PaRes_match_attempted_then_should_return_null() {
         // Given
         String html = "";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
                 .isNull();
     }
 
@@ -25,10 +163,10 @@ public class D3SRegexUtilsTest {
         String html = "               ";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
                 .isNull();
     }
 
@@ -43,10 +181,10 @@ public class D3SRegexUtilsTest {
                 "</html>";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
                 .isNull();
     }
 
@@ -65,15 +203,15 @@ public class D3SRegexUtilsTest {
                 "</html>";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
                 .isNull();
     }
 
     @Test
-    public void given_html_with_valid_pares_when_PaRes_match_attempted_then_should_return_null() {
+    public void given_html_with_valid_pares_when_PaRes_match_attempted_then_should_return_pares() {
         // Given
         String html = "<html>" +
                 "<head>\n" +
@@ -86,15 +224,15 @@ public class D3SRegexUtilsTest {
                 "</html>";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
                 .isEqualTo("pares_value");
     }
 
     @Test
-    public void given_html_with_valid_pares_case_insensitive_when_PaRes_match_attempted_then_should_return_null() {
+    public void given_html_with_valid_pares_case_insensitive_when_PaRes_match_attempted_then_should_return_pares() {
         // Given
         String html = "<html>" +
                 "<head>\n" +
@@ -107,10 +245,39 @@ public class D3SRegexUtilsTest {
                 "</html>";
 
         // When
-        String paRes = D3SRegexUtils.findPaRes(html);
+        String result = D3SRegexUtils.findPaRes(html);
 
         // Then
-        assertThat(paRes)
+        assertThat(result)
+                .isEqualTo("pares_value");
+    }
+
+    @Test
+    public void given_html_with_valid_pares_multiline_when_PaRes_match_attempted_then_should_return_pares() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input" +
+                "    type=\"hidden\" " +
+                "    id=\"PaRes\" " +
+                "    name=\"pares\" " +
+                "    value=\"pares_value\">\n" +
+                "  <input " +
+                "   type=\"hidden\" " +
+                "   id=\"MD\" " +
+                "   name=\"MD\" " +
+                "   value=\"\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String result = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(result)
                 .isEqualTo("pares_value");
     }
 }

--- a/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
+++ b/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
@@ -1,0 +1,95 @@
+package eu.livotov.labs.android.d3s;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class D3SRegexUtilsTest {
+
+    @Test
+    public void given_empty_html_when_PaRes_match_attempted_then_should_return_null() {
+        // Given
+        String html = "";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isNull();
+    }
+
+    @Test
+    public void given_blank_html_when_PaRes_match_attempted_then_should_return_null() {
+        // Given
+        String html = "               ";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_no_pares_when_PaRes_match_attempted_then_should_return_null() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<div class=\"threeds-one\">" +
+                "</html>";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_empty_pares_when_PaRes_match_attempted_then_should_return_null() {
+        // https://github.com/LivotovLabs/3DSView/issues/30
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"PaRes\" value=\"\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"MD\" value=\"\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isNull();
+    }
+
+    @Test
+    public void given_html_with_valid_pares_when_PaRes_match_attempted_then_should_return_null() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"PaRes\" value=\"pares_value\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"MD\" value=\"\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isEqualTo("pares_value");
+    }
+}

--- a/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
+++ b/3DSView/src/test/java/eu/livotov/labs/android/d3s/D3SRegexUtilsTest.java
@@ -92,4 +92,25 @@ public class D3SRegexUtilsTest {
         assertThat(paRes)
                 .isEqualTo("pares_value");
     }
+
+    @Test
+    public void given_html_with_valid_pares_case_insensitive_when_PaRes_match_attempted_then_should_return_null() {
+        // Given
+        String html = "<html>" +
+                "<head>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "<form method=\"POST\" id=\"TermForm\">\n" +
+                "  <input type=\"hidden\" id=\"PaRes\" name=\"pares\" value=\"pares_value\">\n" +
+                "  <input type=\"hidden\" id=\"MD\" name=\"MD\" value=\"\">\n" +
+                "</form>" +
+                "</html>";
+
+        // When
+        String paRes = D3SRegexUtils.findPaRes(html);
+
+        // Then
+        assertThat(paRes)
+                .isEqualTo("pares_value");
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha14'
+        classpath 'com.android.tools.build:gradle:4.2.0-alpha16'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Address #30 .

I've only migrated the matchers for 3DSv1 (PaRes and MD). Let me know if you want me to also do 3DSv2. Of course, first let me know if this is a worthwhile route to go down. I've tried to do the following:

1) Extract the matching to a separate class.
2) This allows us to write tests.
3) Distilled the regex into a single pattern.
4) Added nullability annotations so that we can make the code as safe as possible and get the IDE to help where needed.

However, at the heart of it is the change to the `valuePattern` in `D3SView`. This is what prevents blank / empty matches seen in the linked issue.