### PR TITLE
Set Android Gradle Plugin to latest stable (4.1.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-alpha16'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Resolves comment about not forcing the canary version of Android Studio on contributors in https://github.com/LivotovLabs/3DSView/issues/33#issuecomment-749045492.