### PR TITLE
Fix lint warnings: AddJavascriptInterface, SetJavaScriptEnabled, WrongConstant

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -6,9 +6,6 @@ import androidx.annotation.Nullable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static java.util.regex.Pattern.DOTALL;
-import static java.util.regex.Pattern.compile;
 
 /**
  * Utilities to find 3DS values in ACS webpages.
@@ -18,12 +15,12 @@ final class D3SRegexUtils {
     /**
      * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of MD.
      */
-    private static final Pattern mdFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"MD\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
+    private static final Pattern mdFinder = Pattern.compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"MD\"[^<>]+?>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     /**
      * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of PaRes.
      */
-    private static final Pattern paresFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"PaRes\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
+    private static final Pattern paresFinder = Pattern.compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"PaRes\"[^<>]+?>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     /**
      * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of CRes.

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -1,5 +1,6 @@
 package eu.livotov.labs.android.d3s;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -72,6 +73,7 @@ public class D3SView extends WebView {
         initUI();
     }
 
+    @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
     private void initUI() {
         getSettings().setJavaScriptEnabled(true);
         getSettings().setBuiltInZoomControls(true);


### PR DESCRIPTION
## Fix Lint Warnings (Issue #8)

Resolves #8

### Changes

#### 1. D3SView.java -- Add @SuppressLint for SetJavaScriptEnabled and AddJavascriptInterface

- **Why:** JavaScript is fundamental to how this 3DS WebView component works -- it injects JS to extract payment authorization data (MD, PaRes, CRes) from the ACS page. The lint warning about XSS is acknowledged but accepted since the component only loads trusted ACS server pages provided by payment gateways.
- addJavascriptInterface is required for the JS bridge (D3SJSInterface) that captures HTML from the ACS page. The class already correctly uses @JavascriptInterface annotation on exposed methods.
- Added import: android.annotation.SuppressLint

#### 2. D3SRegexUtils.java -- Use qualified Pattern.compile() instead of static import

- **Why:** The WrongConstant lint warning was triggered because the static import of compile made lint unable to verify that the integer flags (DOTALL | CASE_INSENSITIVE) are valid Pattern flag constants. Using the fully qualified Pattern.compile() resolves this.
- Removed unused static imports of compile, DOTALL, and CASE_INSENSITIVE.

### Testing

- No behavioral changes -- all fixes are lint warning suppressions and equivalent code restructuring.
- Compiled and verified D3SRegexUtils.java -- 15/15 regex tests passed (MD, PaRes, CRes, threeDSSessionData extraction including case-insensitive and multiline/DOTALL scenarios).

### Note on `minSdkVersion`

The `AddJavascriptInterface` lint warning exists because `minSdkVersion` is currently set to **10**. On API < 17, `addJavascriptInterface` exposes all public methods via JavaScript reflection, which is a known security vulnerability ([CVE-2012-6636](https://nvd.nist.gov/vuln/detail/CVE-2012-6636)).

This PR suppresses the warning with `@SuppressLint`, which is the least invasive approach. However, raising `minSdkVersion` to **17** would eliminate the vulnerability at its root rather than just silencing the lint check.

That said, changing `minSdkVersion` is a **project-wide decision** -- it would drop support for Android 2.3–4.1 devices entirely and could affect any app that depends on this library. While those API levels represent effectively 0% of active devices today, it's a change the maintainers should evaluate for their user base.

If raising the minimum SDK is acceptable, the `@SuppressLint("AddJavascriptInterface")` annotation could be removed in favor of that.
