### PR TITLE
Enable DOM storage so onAuthorizationCompleted fires for ACS pages that need localStorage

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -74,6 +74,7 @@ public class D3SView extends WebView {
 
     private void initUI() {
         getSettings().setJavaScriptEnabled(true);
+        getSettings().setDomStorageEnabled(true);
         getSettings().setBuiltInZoomControls(true);
         addJavascriptInterface(new D3SJSInterface(), JavaScriptNS);
 


### PR DESCRIPTION
## Enable DOM storage by default

Resolves #12

Several banks (Swedish issuers reported in the linked issue, and a few
others I have hit while integrating) refuse to advance past the 3D Secure
page unless `window.localStorage` is available. The ACS script reads or
writes a small key, gets a `SecurityError`, and the form that should have
been posted to the postback URL is never produced. From the app side that
looks like `onAuthorizationCompleted` never being called.

The fix is one line. Turn on DOM storage in `initUI` so the WebView matches
what every modern browser already does.

```java
getSettings().setDomStorageEnabled(true);
```

### Why this is safe

DOM storage is sandboxed per origin. Enabling it does not expose any new
data to the host app and it is a strict superset of the previous behaviour.
Pages that did not need it before will not notice the change.

### Testing

Local smoke test against a sandbox 3DS flow that previously stalled now
completes and triggers the listener.
