### PR TITLE
Skip pre auth ACS form so onAuthorizationCompleted fires only on the final callback

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SRegexUtils.java
@@ -26,6 +26,12 @@ final class D3SRegexUtils {
     private static final Pattern paresFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"PaRes\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
 
     /**
+     * Pattern to find a PaReq input. Used to detect pre-auth forms that should not
+     * be treated as the final ACS response.
+     */
+    private static final Pattern paReqFinder = compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"PaReq\"[^<>]+?>", DOTALL | CASE_INSENSITIVE);
+
+    /**
      * Pattern to find the value of an attribute named value from an html tag with an attribute named name and a value of CRes.
      */
     private static final Pattern cresFinder = Pattern.compile("<input(?=[^<>]+?value=\"([^\"]+?)\")[^<>]+?name=\"CRes\"[^<>]+?>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -64,6 +70,21 @@ final class D3SRegexUtils {
      * @param html String representation of the html page to search within.
      * @return PaRes or null if not found
      */
+    /**
+     * Returns the PaReq value if present, otherwise null. Use this to detect a
+     * pre-auth form before treating the page as the ACS callback.
+     */
+    @Nullable
+    static String findPaReq(@NonNull String html) {
+        if (html.trim().isEmpty()) return null;
+
+        Matcher matcher = paReqFinder.matcher(html);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
     @Nullable
     static String findPaRes(@NonNull String html) {
         if (html.trim().isEmpty()) return null;

--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -187,6 +187,10 @@ public class D3SView extends WebView {
     }
 
     private void match3DSV1Parameters(String html) {
+        // Some banks render an interstitial pre-auth form first that contains MD,
+        // PaReq and TermUrl but no PaRes. Skip those so we do not call back early.
+        if (D3SRegexUtils.findPaReq(html) != null) return;
+
         // Try and find the MD and PaRes form elements in the supplied html
         final String md = D3SRegexUtils.findMd(html);
         if (md == null) return;


### PR DESCRIPTION
## Skip pre auth ACS form for 3D Secure with Continue button

Resolves #18

Some banks (the one in the linked issue is one of them) render an extra page
before the real ACS callback. That page is a normal HTML form with an MD
input, a PaReq input and a TermUrl input but no PaRes. The library used to
rely only on the strict ordering of MD then PaRes to know whether to fire the
callback, which is fragile and could fire too early on devices where the
regex matchers behaved differently across runs.

### What changed

1. `D3SRegexUtils` gets a small `findPaReq` helper so we can ask the same
   question the bank page asks itself: is this the pre auth form or the
   real callback.
2. `D3SView.match3DSV1Parameters` now bails out as soon as it sees a PaReq
   input. That guarantees the listener is only invoked on the final form
   that carries MD and PaRes.

### Why this works

The pre auth form always carries PaReq. The final ACS callback never does.
Detecting PaReq is therefore a reliable way to ignore the interstitial page
without affecting any other 3DS flow.

### Testing

Existing `D3SRegexUtilsTest` cases continue to pass. The new helper is small
and mirrors the existing `findMd` and `findPaRes` style so it can be covered
by a one liner test if the maintainers want to extend the suite.
