### PR TITLE
Render ACS pages at their native viewport instead of auto zooming in

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -75,6 +75,9 @@ public class D3SView extends WebView {
     private void initUI() {
         getSettings().setJavaScriptEnabled(true);
         getSettings().setBuiltInZoomControls(true);
+        // Render bank pages at their native scale so they are not auto zoomed in.
+        getSettings().setUseWideViewPort(true);
+        getSettings().setLoadWithOverviewMode(true);
         addJavascriptInterface(new D3SJSInterface(), JavaScriptNS);
 
         setWebViewClient(new WebViewClient() {


### PR DESCRIPTION
## Render bank pages at native scale

Resolves #19

When the ACS page opens, the WebView ignores the page viewport and renders
the body at the default WebView scale, which makes the form appear zoomed
in. The fix is to enable wide viewport plus overview mode so the page is
first laid out at its declared width and then scaled to fit the WebView.

```java
getSettings().setUseWideViewPort(true);
getSettings().setLoadWithOverviewMode(true);
```

Pinch to zoom still works because `setBuiltInZoomControls(true)` is kept.
Users who actually want to zoom in can still do so manually, the page just
no longer starts off zoomed in.

### Testing

Verified against a Visa sandbox ACS page on a Pixel 6 emulator. Before the
change the form opened roughly 2x. After the change it opens at the same
scale a desktop browser would render it.
