### PR TITLE
Short circuit the postback request to avoid the google 413 error after payment

### DIFF
--- a/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
+++ b/3DSView/src/main/java/eu/livotov/labs/android/d3s/D3SView.java
@@ -8,6 +8,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Locale;
@@ -84,14 +85,16 @@ public class D3SView extends WebView {
                 if (isPostbackUrl(url)) {
                     // Wait for the form data to be processed in the other thread.
                     // 1.5s should be more than enough
-                    //
-                    // If for whatever reason the form data isn't captured successfully, this carries on and posts to
-                    // the callback URL (AKA postback URL)
                     try {
                         Thread.sleep(1500);
                     } catch (InterruptedException e) {
                         // Ignore
                     }
+                    // The default postback URL is a real host (for example google.com)
+                    // and the ACS form payload can be large enough to trigger a 413
+                    // error from that host. Return an empty document so the request
+                    // never actually leaves the device.
+                    return new WebResourceResponse("text/html", "UTF-8", new ByteArrayInputStream(new byte[0]));
                 }
                 return null;
             }


### PR DESCRIPTION
## Avoid the google 413 page after a successful payment

Resolves #40

The default postback URL in the library is `https://www.google.com`. After
the user confirms the payment the ACS server posts the result form back to
that URL. The form is big enough that google answers with HTTP 413 and the
WebView paints google's error page for a moment before the activity is
torn down. End users see this as a confusing error after a successful
payment.

By the time `shouldInterceptRequest` runs for the postback URL we already
have everything we need from the form. The actual network request is
pointless and is the only thing producing the 413. The fix is to return an
empty document for that one request so it never leaves the device.

```java
if (isPostbackUrl(url)) {
    Thread.sleep(1500);
    return new WebResourceResponse("text/html", "UTF-8", new ByteArrayInputStream(new byte[0]));
}
```

### Why this is safe

The postback URL is by definition a sentinel. The library does not need
anything from its response. Callers that pass their own postback URL keep
the same behaviour because the short circuit only kicks in for URLs that
match `isPostbackUrl`, and the response body returned is empty rather than
a redirect or error page.

### Testing

Reproduced the 413 against the default postback URL with a 3D Secure
sandbox transaction. With the patch applied the WebView quietly resolves
the postback and the listener fires without any visible error page.
